### PR TITLE
Tiny tweaks to background-refresh-cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ class Cache extends EventEmitter {
         if (cached.fetchedAt < freshAfter) {
           debug("Freshening %j because content fetched at %j is older than %j", key, cached.fetchedAt, freshAfter);
           this.fetch(key).catch(err => {
-            console.log('error will robinson:', err)
             if (err.statusCode == 404) {
               debug("Deleting %j from cache", key);
               return pool.withConnection(redis => {


### PR DESCRIPTION
It turns out the CMS agent was expecting to see `fetchedAt` and `fetchedFromCacheAt`, so I made that happen.

Also added a few tests to make sure it works as the CMS agent expects it to.
